### PR TITLE
remove software directory reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ disable this section of the script, by setting `True` to `False`.
     ```bash
     git clone https://github.com/ewancarr/NEWS2-COVID-19
     cd NEWS2-COVID-19
-    pip install -r software/requirements.txt
+    pip install -r requirements.txt
     python replicate.py
     ```
 


### PR DESCRIPTION
This repo has really nice docs! This is a tiny tiny fix- the `software` directory isn't present in the code - to run it, you need to remove this directory from the filepath. I'm guessing it might be left behind from a point in time where this directory _was_ present :) 